### PR TITLE
Path issue fix.

### DIFF
--- a/move.py
+++ b/move.py
@@ -5,19 +5,22 @@ from paths import set_shared_cache_folder
 
 
 def move_cache(src, dest):
-    if os.path.exists(dest):
-        if os.path.isfile(dest):
-            print "'%s' exists as a file - can't move SharedCache folder" % dest
+    if sys.platform != "darwin":
+        if os.path.exists(dest):
+            if os.path.isfile(dest):
+                print "'%s' exists as a file - can't move SharedCache folder" % dest
+                sys.exit(1)
+
+            print "'%s' already exists - can't move SharedCache folder" % dest
             sys.exit(1)
 
-        print "'%s' already exists - can't move SharedCache folder" % dest
-        sys.exit(1)
+        try:
+            shutil.move(src, dest)
+        except (IOError, OSError):
+            pass
 
-    try:
-        shutil.move(src, dest)
-    except (IOError, OSError):
-        pass
+        set_shared_cache_folder(dest)
 
-    set_shared_cache_folder(dest)
-
-    print "SharedCache location has been moved to '%s'" % dest
+        print "SharedCache location has been moved to '%s'" % dest
+    else:
+        print "The SharedCache location cannot be moved on Mac"

--- a/paths_mac.py
+++ b/paths_mac.py
@@ -2,11 +2,13 @@ import os
 
 
 def get_shared_cache_folder():
-    return "~/Library/Application Support/EVE Online/p_drive/Local Settings/Application Data/CCP/EVE/SharedCache"
+    home = os.path.expanduser('~/')
+    return home + "Library/Application Support/EVE Online/p_drive/Local Settings/Application Data/CCP/EVE/SharedCache"
 
 
 def set_shared_cache_folder(folder_path):
     pass
+
 
 def get_index_path(hint):
     if os.path.exists(hint):


### PR DESCRIPTION
The change in paths_mac.py fixes the issue of the rescache.py tool looking for the sharedcache folder inside of its root-folder, but instead at the fixed Mac location.

As this location should currently be fixed, the move.py function has been changed to not do anything on the Mac.
